### PR TITLE
junit4 개발환경 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,5 +10,5 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
gradle testCompile가 deprecated됨에 따라 testImplementatoin로 대체할 필요가
있다. 이때 프로덕션 코드에서 junit4 참조가 필요하다. implementatoin을 사용해
테스트 의존성이 프로덕션 의존성으로 등록한다.

related to: #1