### PR TITLE
RepeatRunner 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea/
 .gradle/
+build/

--- a/src/main/java/org/jwchung/junit4pioneer/Repeat.java
+++ b/src/main/java/org/jwchung/junit4pioneer/Repeat.java
@@ -1,0 +1,12 @@
+package org.jwchung.junit4pioneer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Repeat {
+    int value();
+}

--- a/src/main/java/org/jwchung/junit4pioneer/RepeatRunner.java
+++ b/src/main/java/org/jwchung/junit4pioneer/RepeatRunner.java
@@ -1,0 +1,34 @@
+package org.jwchung.junit4pioneer;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RepeatRunner extends BlockJUnit4ClassRunner {
+
+    public RepeatRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+    }
+
+    @Override
+    protected List<FrameworkMethod> computeTestMethods() {
+        return computeRepeatMethods();
+    }
+
+    private List<FrameworkMethod> computeRepeatMethods() {
+        List<FrameworkMethod> repeatMethods = new ArrayList<>();
+
+        for (FrameworkMethod method: super.computeTestMethods()) {
+            Repeat repeat = method.getAnnotation(Repeat.class);
+            for (int i = 0; i < repeat.value(); i++) {
+                repeatMethods.add(method);
+            }
+        }
+
+        return Collections.unmodifiableList(repeatMethods);
+    }
+}

--- a/src/test/java/org/jwchung/junit4pioneer/RepeatRunnerTest.java
+++ b/src/test/java/org/jwchung/junit4pioneer/RepeatRunnerTest.java
@@ -1,0 +1,25 @@
+package org.jwchung.junit4pioneer;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+public class RepeatRunnerTest {
+
+    @RunWith(RepeatRunner.class)
+    public static class MyTestClass {
+        @Test
+        @Repeat(10)
+        public void testMyCode10Times() {
+        }
+    }
+
+    @Test
+    public void sutCorrectlyRepeatsTestRunForSpecifiedNumberOfTimes() {
+        Result result = JUnitCore.runClasses(MyTestClass.class);
+        assertEquals(10, result.getRunCount());
+    }
+}


### PR DESCRIPTION
지정한 반복 수 만큼 테스트 메소드를 실행하는 RepeatRunner를 구현한다.
BlockJUnit4ClassRunner 클래스를 상속해 테스트케이스에 대응하는
FrameworkMethod의 인스턴스를 지정한 반복수 만큼 생성한다.

related issue: #5