### PR TITLE
상속 대신 구성 사용

### DIFF
--- a/src/main/java/org/jwchung/junit4pioneer/RepeatRunner.java
+++ b/src/main/java/org/jwchung/junit4pioneer/RepeatRunner.java
@@ -4,34 +4,63 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
-public class RepeatRunner extends BlockJUnit4ClassRunner {
+public class RepeatRunner extends Runner {
+    private final Class<?> klass;
 
-    public RepeatRunner(Class<?> klass) throws InitializationError {
-        super(klass);
+    public RepeatRunner(Class<?> klass) {
+        this.klass = klass;
     }
 
     @Override
-    protected List<FrameworkMethod> computeTestMethods() {
-        return computeRepeatMethods();
+    public Description getDescription() {
+        return createProxyRunner().getDescription();
     }
 
-    private List<FrameworkMethod> computeRepeatMethods() {
-        List<FrameworkMethod> repeatMethods = new ArrayList<>();
+    @Override
+    public void run(RunNotifier notifier) {
+        createProxyRunner().run(notifier);
+    }
 
-        for (FrameworkMethod method: super.computeTestMethods()) {
-            Repeat repeat = method.getAnnotation(Repeat.class);
+    private Runner createProxyRunner() {
+        try {
+            return createProxyRunnerUnsafely();
+        } catch (InitializationError initializationError) {
+            String message = "Error occurred when initializing an instance of "
+                    + "the BlockJUnit4ClassRunner type.";
 
-            int repeatValue = repeat == null ? 1 : repeat.value();
-
-            for (int i = 0; i < repeatValue; i++) {
-                repeatMethods.add(method);
-            }
+            throw new RuntimeException(message, initializationError);
         }
+    }
 
-        return Collections.unmodifiableList(repeatMethods);
+    private BlockJUnit4ClassRunner createProxyRunnerUnsafely() throws InitializationError {
+        return new BlockJUnit4ClassRunner(klass) {
+            @Override
+            protected List<FrameworkMethod> computeTestMethods() {
+                return computeRepeatMethods();
+            }
+
+            private List<FrameworkMethod> computeRepeatMethods() {
+                List<FrameworkMethod> repeatMethods = new ArrayList<>();
+
+                for (FrameworkMethod method : super.computeTestMethods()) {
+                    Repeat repeat = method.getAnnotation(Repeat.class);
+
+                    int repeatValue = repeat == null ? 1 : repeat.value();
+
+                    for (int i = 0; i < repeatValue; i++) {
+                        repeatMethods.add(method);
+                    }
+                }
+
+                return Collections.unmodifiableList(repeatMethods);
+            }
+        };
     }
 }


### PR DESCRIPTION
BlockJUnit4ClassRunner 상속(is-a)을 버리고 프록시를 소유하는 구성(has-a)으로
변경한다. 이 변경은 상속으로 불필요하게 노출되는 BlockJUnit4ClassRunner
공용멤버를 숨겨 불필요한 결합을 방지한다.