### PR TITLE
FirstClassTestRunner 구현

### DIFF
--- a/src/main/java/org/jwchung/junit4pioneer/FirstClassTestCase.java
+++ b/src/main/java/org/jwchung/junit4pioneer/FirstClassTestCase.java
@@ -1,0 +1,6 @@
+package org.jwchung.junit4pioneer;
+
+@FunctionalInterface
+public interface FirstClassTestCase {
+    void invoke();
+}

--- a/src/main/java/org/jwchung/junit4pioneer/FirstClassTestCaseMethod.java
+++ b/src/main/java/org/jwchung/junit4pioneer/FirstClassTestCaseMethod.java
@@ -1,0 +1,24 @@
+package org.jwchung.junit4pioneer;
+
+import org.junit.runners.model.FrameworkMethod;
+
+/**
+ * Represents a first-class test case.
+ */
+public class FirstClassTestCaseMethod {
+    private final FrameworkMethod declaringMethod;
+    private final FirstClassTestCase testCase;
+
+    public FirstClassTestCaseMethod(FrameworkMethod declaringMethod, FirstClassTestCase testCase) {
+        this.declaringMethod = declaringMethod;
+        this.testCase = testCase;
+    }
+
+    public FrameworkMethod getDeclaringMethod() {
+        return declaringMethod;
+    }
+
+    public void invoke() {
+        testCase.invoke();
+    }
+}

--- a/src/main/java/org/jwchung/junit4pioneer/FirstClassTestRunner.java
+++ b/src/main/java/org/jwchung/junit4pioneer/FirstClassTestRunner.java
@@ -1,0 +1,188 @@
+package org.jwchung.junit4pioneer;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+
+public class FirstClassTestRunner extends ParentRunner<FirstClassTestCaseMethod> {
+    private final ConcurrentHashMap<FrameworkMethod, Description> methodDescriptions =
+            new ConcurrentHashMap<>();
+
+    public FirstClassTestRunner(Class<?> declaringClass) throws InitializationError {
+        super(declaringClass);
+    }
+
+    @Override
+    protected List<FirstClassTestCaseMethod> getChildren() {
+        return getTestClass()
+                .getAnnotatedMethods(Test.class)
+                .stream()
+                .flatMap(declaringMethod -> {
+                    try {
+                        return new FirstClassTestCaseMethodComposer(
+                                declaringMethod, getDeclaringClass())
+                                .compose();
+                    } catch (RuntimeException exception) {
+                        throw exception;
+                    } catch (Throwable throwable) {
+                        // do nothing to throw an exception as no tests found.
+                    }
+                    return Stream.empty();
+                }).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Description describeChild(FirstClassTestCaseMethod child) {
+        FrameworkMethod declaringMethod = child.getDeclaringMethod();
+        Description description = methodDescriptions.get(declaringMethod);
+
+        if (description == null) {
+            description = Description.createTestDescription(getTestClass().getJavaClass(),
+                    testName(declaringMethod), declaringMethod.getAnnotations());
+            methodDescriptions.putIfAbsent(declaringMethod, description);
+        }
+
+        return description;
+    }
+
+    @Override
+    protected void runChild(FirstClassTestCaseMethod child, RunNotifier notifier) {
+        Description description = describeChild(child);
+        runLeaf(testCaseMethodBlock(child), description, notifier);
+    }
+
+    private TestClass getDeclaringClass() {
+        return super.getTestClass();
+    }
+
+    private Statement testCaseMethodBlock(FirstClassTestCaseMethod testCaseMethod) {
+        return new Statement() {
+            @Override
+            public void evaluate() {
+                testCaseMethod.invoke();
+            }
+        };
+    }
+
+    protected String testName(FrameworkMethod method) {
+        return method.getName();
+    }
+
+    private static class FirstClassTestCaseMethodComposer {
+        private final FrameworkMethod declaringMethod;
+        private final TestClass declaringClass;
+
+        public FirstClassTestCaseMethodComposer(
+                FrameworkMethod declaringMethod, TestClass declaringClass) {
+
+            this.declaringMethod = declaringMethod;
+            this.declaringClass = declaringClass;
+        }
+
+        public Stream<FirstClassTestCaseMethod> compose() throws Throwable {
+            Class<?> returnType = declaringMethod.getReturnType();
+
+            if (void.class.isAssignableFrom(returnType)) {
+                return composeNormalTestCaseMethod();
+            }
+
+            if (Iterable.class.isAssignableFrom(returnType)) {
+                return composeIterableTestCaseMethods();
+            }
+
+            if (Stream.class.isAssignableFrom(returnType)) {
+                return composeStreamTestCaseMethods();
+            }
+
+            String message = String.format(
+                    "The returned type '%s' isn't supported"
+                            + " on FirstClassTestRunner. Void, Iterable<FirstClassTestCase> or"
+                            + "  Stream<FirstClassTestCase> types are only supported.",
+                    returnType);
+
+            throw new ClassCastException(message);
+        }
+
+        private Stream<FirstClassTestCaseMethod> composeNormalTestCaseMethod() {
+            return Stream.of(new FirstClassTestCaseMethod(
+                    declaringMethod,
+                    () -> {
+                        try {
+                            declaringMethod.invokeExplosively(createDeclaringClassObject());
+                        } catch (Throwable throwable) {
+                            String message = "Thrown while creating an instance of"
+                                    + " the test class.";
+                            throw new RuntimeException(
+                                    message,
+                                    throwable);
+                        }
+                    }));
+        }
+
+        private Stream<FirstClassTestCaseMethod> composeIterableTestCaseMethods()
+                throws Throwable {
+            Object obj = declaringMethod
+                    .invokeExplosively(createDeclaringClassObject());
+
+            Iterable<?> testCases = (Iterable<?>) obj;
+
+            return StreamSupport
+                    .stream(testCases.spliterator(), false)
+                    .map(testCase -> {
+                        if (testCase instanceof FirstClassTestCase) {
+                            return new FirstClassTestCaseMethod(
+                                    declaringMethod, (FirstClassTestCase) testCase);
+                        } else {
+                            return throwClassCastException(
+                                    testCases.getClass(), testCase.getClass());
+                        }
+                    });
+        }
+
+        private Stream<FirstClassTestCaseMethod> composeStreamTestCaseMethods()
+                throws Throwable {
+            Object obj = declaringMethod
+                    .invokeExplosively(createDeclaringClassObject());
+
+            Stream<?> testCases = (Stream<?>) obj;
+
+            return testCases
+                    .map(testCase -> {
+                        if (testCase instanceof FirstClassTestCase) {
+                            return new FirstClassTestCaseMethod(
+                                    declaringMethod, (FirstClassTestCase) testCase);
+                        } else {
+                            return throwClassCastException(
+                                    testCases.getClass(), testCase.getClass());
+                        }
+                    });
+        }
+
+        private Object createDeclaringClassObject() throws Exception {
+            return declaringClass.getOnlyConstructor().newInstance();
+        }
+
+        private FirstClassTestCaseMethod throwClassCastException(
+                Class<?> genericType, Class<?> argumentType) {
+            String message = String.format(
+                    "The returned type '%s[%s]' isn't supported"
+                            + " on FirstClassTestRunner. Void, Iterable<FirstClassTestCase> or"
+                            + "  Stream<FirstClassTestCase> types are only supported.",
+                    genericType,
+                    argumentType);
+
+            throw new ClassCastException(message);
+        }
+    }
+}

--- a/src/test/java/org/jwchung/junit4pioneer/FirstClassTestRunnerTest.java
+++ b/src/test/java/org/jwchung/junit4pioneer/FirstClassTestRunnerTest.java
@@ -1,0 +1,99 @@
+package org.jwchung.junit4pioneer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class FirstClassTestRunnerTest {
+    @RunWith(FirstClassTestRunner.class)
+    public static class IterableTestCases {
+        @Test
+        public Iterable<FirstClassTestCase> createIterableTestCases() {
+            int[] testData = {
+                    1, 1, 1
+            };
+
+            return Arrays.stream(testData).mapToObj(x -> (FirstClassTestCase) () ->
+                    assertEquals(x, 1)).collect(Collectors.toList());
+        }
+
+        @Test
+        public List<FirstClassTestCase> createListTestCases() {
+            int[] testData = {
+                    2, 2
+            };
+
+            return Arrays.stream(testData).mapToObj(x -> (FirstClassTestCase) () ->
+                    assertEquals(x, 2)).collect(Collectors.toList());
+        }
+    }
+
+    @Test
+    public void sutCorrectlyRunsIterableFirstClassTestCases() {
+        Result result = JUnitCore.runClasses(IterableTestCases.class);
+        assertEquals(5, result.getRunCount());
+        assertEquals(0, result.getFailureCount());
+    }
+
+    @RunWith(FirstClassTestRunner.class)
+    public static class NormalTestCases {
+        private static Boolean recordIsExecuted = false;
+
+        @Test
+        public Iterable<FirstClassTestCase> createTestCases() {
+            int[] testData = {
+                    1, 1
+            };
+
+            return Arrays.stream(testData).mapToObj(x -> (FirstClassTestCase) () ->
+                    assertEquals(x, 1)).collect(Collectors.toList());
+        }
+
+        @Test
+        public void voidTestCase() {
+            recordIsExecuted = true;
+        }
+    }
+
+    @Test
+    public void sutCorrectlyRunsVoidTestCases() {
+        NormalTestCases.recordIsExecuted = false;
+
+        Result result = JUnitCore.runClasses(NormalTestCases.class);
+
+        assertEquals(3, result.getRunCount());
+        assertEquals(0, result.getFailureCount());
+        assertTrue(NormalTestCases.recordIsExecuted);
+    }
+
+    @RunWith(FirstClassTestRunner.class)
+    public static class StreamTestCases {
+        @Test
+        public Stream<FirstClassTestCase> createTestCases() {
+            int[] testData = {
+                    1, 1
+            };
+
+            return Arrays.stream(testData).mapToObj(x -> () ->
+                    assertEquals(x, 1));
+        }
+    }
+
+    @Test
+    public void sutCorrectlyRunsStreamFirstClassTestCases() {
+        Result result = JUnitCore.runClasses(StreamTestCases.class);
+        assertEquals(2, result.getRunCount());
+        assertEquals(0, result.getFailureCount());
+    }
+}


### PR DESCRIPTION
람다식으로 표현되는 테스트케이스를 반환하여 Parameterized Tests를 구현한다.
이것은 테스트와 데이터를 한데 묶을 수 있고, 컴파일 타임에 타입 안전성을 보장 할 수
있는 장점이 있다. 자세한 내용은 여기 https://github.com/jwChung/junit4-pioneer/issues/15 를
참고한다.

related to: #15