### PR TITLE
패키지 이름 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'checkstyle'
 }
 
-group 'org.jwchung'
-version '0.1.0'
+group 'com.github.jwchung'
+version '0.0.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCase.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCase.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 @FunctionalInterface
 public interface FirstClassTestCase {

--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCaseMethod.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCaseMethod.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 import org.junit.runners.model.FrameworkMethod;
 

--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestRunner.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestRunner.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/github/jwchung/junit4pioneer/Repeat.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/Repeat.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/github/jwchung/junit4pioneer/RepeatRunner.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/RepeatRunner.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/com/github/jwchung/junit4pioneer/FirstClassTestRunnerTest.java
+++ b/src/test/java/com/github/jwchung/junit4pioneer/FirstClassTestRunnerTest.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/com/github/jwchung/junit4pioneer/RepeatRunnerTest.java
+++ b/src/test/java/com/github/jwchung/junit4pioneer/RepeatRunnerTest.java
@@ -1,4 +1,4 @@
-package org.jwchung.junit4pioneer;
+package com.github.jwchung.junit4pioneer;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
org.jwchung -> com.github.jwchung로 패키지 이름을 변경한다. 다음 링크와 같이
패키지 이름에 대응하는 maven repository를 만들려면 도메인에 대한 소유권 내지는
github과 같이 알려진 도메인에 대한 계정 경로를 사용해야 한다.

https://issues.sonatype.org/browse/OSSRH-60221?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

related to: #16