### PR TITLE
FirstClassTestCaseMethod 접근자 제한

### DIFF
--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCaseMethod.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCaseMethod.java
@@ -3,13 +3,14 @@ package com.github.jwchung.junit4pioneer;
 import org.junit.runners.model.FrameworkMethod;
 
 /**
- * Represents a first-class test case.
+ * Represents a first-class test-case method.
  */
-public class FirstClassTestCaseMethod {
+class FirstClassTestCaseMethod {
     private final FrameworkMethod declaringMethod;
     private final FirstClassTestCase testCase;
 
-    public FirstClassTestCaseMethod(FrameworkMethod declaringMethod, FirstClassTestCase testCase) {
+    public FirstClassTestCaseMethod(
+            FrameworkMethod declaringMethod, FirstClassTestCase testCase) {
         this.declaringMethod = declaringMethod;
         this.testCase = testCase;
     }


### PR DESCRIPTION
FirstClassTestCaseMethod는 외부에서 사용할 필요가 없어 default 접근자로 제한한다.

related to: #26

closes #26