### PR TITLE
실행된 테스트 이름을 기록하기 위해 RunListener 사용

### DIFF
--- a/src/test/java/com/github/jwchung/junit4pioneer/RepeatRunnerTest.java
+++ b/src/test/java/com/github/jwchung/junit4pioneer/RepeatRunnerTest.java
@@ -6,10 +6,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunListener;
 
 public class RepeatRunnerTest {
 
@@ -29,41 +31,35 @@ public class RepeatRunnerTest {
 
     @RunWith(RepeatRunner.class)
     public static class SeveralRepeatTestMethodsCase {
-        private static final List<String> executedTestNameRecorder = new ArrayList<>();
-
-        private static String getCurrentMethod() {
-            return Thread
-                    .currentThread()
-                    .getStackTrace()[1 + 1]
-                    .getMethodName();
-        }
-
         @Test
         @Repeat(3)
         public void testMyCode3Times() {
-            executedTestNameRecorder.add(getCurrentMethod());
         }
 
         @Test
         @Repeat(5)
         public void testMyCode5Times() {
-            executedTestNameRecorder.add(getCurrentMethod());
         }
 
         @Test
         @Repeat(7)
         public void testMyCode7Times() {
-            executedTestNameRecorder.add(getCurrentMethod());
         }
     }
 
     @Test
     public void sutCorrectlyRepeatsSeveralRepeatTestMethods() {
-        SeveralRepeatTestMethodsCase.executedTestNameRecorder.clear();
+        List<String> executedTestNames = new ArrayList<>();
+        JUnitCore junitCore = new JUnitCore();
+        junitCore.addListener(new RunListener() {
+            @Override
+            public void testFinished(Description description) {
+                executedTestNames.add(description.getMethodName());
+            }
+        });
 
-        JUnitCore.runClasses(SeveralRepeatTestMethodsCase.class);
+        junitCore.run(SeveralRepeatTestMethodsCase.class);
 
-        List<String> executedTestNames = SeveralRepeatTestMethodsCase.executedTestNameRecorder;
         assertEquals(15, executedTestNames.size());
         assertEquals(3, getRepeat(executedTestNames, getTargetTestName(3)));
         assertEquals(5, getRepeat(executedTestNames, getTargetTestName(5)));
@@ -72,12 +68,18 @@ public class RepeatRunnerTest {
 
     @Test
     public void sutRunsOnlySelectedRepeatMethods() {
-        SeveralRepeatTestMethodsCase.executedTestNameRecorder.clear();
+        List<String> executedTestNames = new ArrayList<>();
+        JUnitCore junitCore = new JUnitCore();
+        junitCore.addListener(new RunListener() {
+            @Override
+            public void testFinished(Description description) {
+                executedTestNames.add(description.getMethodName());
+            }
+        });
         String targetTestName = getTargetTestName(3);
 
-        new JUnitCore().run(Request.method(SeveralRepeatTestMethodsCase.class, targetTestName));
+        junitCore.run(Request.method(SeveralRepeatTestMethodsCase.class, targetTestName));
 
-        List<String> executedTestNames = SeveralRepeatTestMethodsCase.executedTestNameRecorder;
         assertEquals(3, executedTestNames.size());
         assertEquals(3, getRepeat(executedTestNames, targetTestName));
     }
@@ -88,34 +90,29 @@ public class RepeatRunnerTest {
 
     @RunWith(RepeatRunner.class)
     public static class RepeatTestMethodWithNormalCase {
-        private static final List<String> executedTestNameRecorder = new ArrayList<>();
-
-        private static String getCurrentMethod() {
-            return Thread
-                    .currentThread()
-                    .getStackTrace()[1 + 1]
-                    .getMethodName();
-        }
-
         @Test
         @Repeat(3)
         public void testMyCode3Times() {
-            executedTestNameRecorder.add(getCurrentMethod());
         }
 
         @Test
         public void normalTestMethod() {
-            executedTestNameRecorder.add(getCurrentMethod());
         }
     }
 
     @Test
     public void sutCorrectlyRunsNormalTestMethod() {
-        RepeatTestMethodWithNormalCase.executedTestNameRecorder.clear();
+        List<String> executedTestNames = new ArrayList<>();
+        JUnitCore junitCore = new JUnitCore();
+        junitCore.addListener(new RunListener() {
+            @Override
+            public void testFinished(Description description) {
+                executedTestNames.add(description.getMethodName());
+            }
+        });
 
-        JUnitCore.runClasses(RepeatTestMethodWithNormalCase.class);
+        junitCore.run(RepeatTestMethodWithNormalCase.class);
 
-        List<String> executedTestNames = RepeatTestMethodWithNormalCase.executedTestNameRecorder;
         assertEquals(4, executedTestNames.size());
         assertEquals(1, getRepeat(executedTestNames, "normalTestMethod"));
     }


### PR DESCRIPTION
static 필드로 테스트 이름을 기록하는 코드를 제거하고 RunListener 사용하여 실행된
테스트이름을 기록한다. 거추장스러운 코드를 제거할 수 있게 되었다.