### PR TITLE
maven artifact를 자동으로 close 후 release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         echo signing.keyId=$GPG_KEY_ID >> gradle.properties
         echo signing.password=$GPG_PASSWORD >> gradle.properties
         echo signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg >> gradle.properties
-        ./gradlew build publish --warn --stacktrace
+        ./gradlew build publish closeAndReleaseRepository --warn --stacktrace
       env:
         GPG_KEY_ARMOR: ${{ secrets.SYNCED_GPG_KEY_ARMOR }}
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'checkstyle'
+    id 'io.codearte.nexus-staging' version '0.22.0'
 }
 
 group 'com.github.jwchung'
@@ -88,3 +89,13 @@ javadoc {
         options.addBooleanOption('html5', true)
     }
 }
+
+nexusStaging {
+    if (project.hasProperty("sonatypeUsername")
+        && project.hasProperty("sonatypePassword") ) {
+        username = sonatypeUsername
+        password = sonatypePassword
+    }
+    stagingProfileId = "845535153553b"
+}
+


### PR DESCRIPTION
아래 링크의 gradle-nexus-staging-plugin을 사용하여 자동 release하도록 구성한다.

https://github.com/Codearte/gradle-nexus-staging-plugin

closes #24