### PR TITLE
improve!: rename classes for building test cases

### DIFF
--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCases.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCases.java
@@ -5,15 +5,15 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class FirstClassTestCases {
-    public static <U> FirstClassTestCasesWithParameters<U> with(Iterable<? extends U> testData) {
+    public static <U> WithTestDataBuilder<U> with(Iterable<? extends U> testData) {
         return with(StreamSupport.stream(testData.spliterator(), false));
     }
 
-    public static <U> FirstClassTestCasesWithParameters<U> with(U[] testData) {
+    public static <U> WithTestDataBuilder<U> with(U[] testData) {
         return with(Arrays.stream(testData));
     }
 
-    public static <U> FirstClassTestCasesWithParameters<U> with(Stream<? extends U> testData) {
-        return new FirstClassTestCasesWithParameters<>(testData);
+    public static <U> WithTestDataBuilder<U> with(Stream<? extends U> testData) {
+        return new WithTestDataBuilder<>(testData);
     }
 }

--- a/src/main/java/com/github/jwchung/junit4pioneer/WithParametersDisplayerBuilder.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/WithParametersDisplayerBuilder.java
@@ -2,11 +2,11 @@ package com.github.jwchung.junit4pioneer;
 
 import java.util.stream.Stream;
 
-public class FirstClassTestCasesWithDisplayer<T> {
+public class WithParametersDisplayerBuilder<T> {
     private final Stream<? extends T> testData;
     private final ParametersDisplayer<? super T> displayer;
 
-    FirstClassTestCasesWithDisplayer(
+    WithParametersDisplayerBuilder(
             Stream<? extends T> testData, ParametersDisplayer<? super T> displayer) {
         this.testData = testData;
         this.displayer = displayer;

--- a/src/main/java/com/github/jwchung/junit4pioneer/WithTestDataBuilder.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/WithTestDataBuilder.java
@@ -2,16 +2,16 @@ package com.github.jwchung.junit4pioneer;
 
 import java.util.stream.Stream;
 
-public class FirstClassTestCasesWithParameters<T> {
+public class WithTestDataBuilder<T> {
     private final Stream<? extends T> testData;
 
-    FirstClassTestCasesWithParameters(Stream<? extends T> testData) {
+    WithTestDataBuilder(Stream<? extends T> testData) {
         this.testData = testData;
     }
 
-    public FirstClassTestCasesWithDisplayer<T> displayParameters(
+    public WithParametersDisplayerBuilder<T> displayParameters(
             ParametersDisplayer<? super T> displayer) {
-        return new FirstClassTestCasesWithDisplayer<>(testData, displayer);
+        return new WithParametersDisplayerBuilder<>(testData, displayer);
     }
 
     public Stream<FirstClassTestCase> run(FirstClassTestCaseWithParameters<? super T> testCase) {


### PR DESCRIPTION
First, the `FirstClassTestCasesWithParameters` class is confused as its
name is similar with the `FirstClassTestCaseWithParameters` inteface.
So it is renamed to `WithTestDataBuilder` to reveal intent. In the
sense, the `FirstClassTestCasesWithDisplayer` class is renamed to
`WithParametersDisplayerBuilder`.