### PR TITLE
improve: rename generic type names

### DIFF
--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCaseWithParameters.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCaseWithParameters.java
@@ -1,6 +1,6 @@
 package com.github.jwchung.junit4pioneer;
 
 @FunctionalInterface
-public interface FirstClassTestCaseWithParameters<T> {
-    void run(T parameters);
+public interface FirstClassTestCaseWithParameters<ParametersT> {
+    void run(ParametersT parameters);
 }

--- a/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCases.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/FirstClassTestCases.java
@@ -5,15 +5,18 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class FirstClassTestCases {
-    public static <U> WithTestDataBuilder<U> with(Iterable<? extends U> testData) {
+    public static <ParametersT> WithTestDataBuilder<ParametersT> with(
+            Iterable<? extends ParametersT> testData) {
         return with(StreamSupport.stream(testData.spliterator(), false));
     }
 
-    public static <U> WithTestDataBuilder<U> with(U[] testData) {
+    public static <ParametersT> WithTestDataBuilder<ParametersT> with(
+            ParametersT[] testData) {
         return with(Arrays.stream(testData));
     }
 
-    public static <U> WithTestDataBuilder<U> with(Stream<? extends U> testData) {
+    public static <ParametersT> WithTestDataBuilder<ParametersT> with(
+            Stream<? extends ParametersT> testData) {
         return new WithTestDataBuilder<>(testData);
     }
 }

--- a/src/main/java/com/github/jwchung/junit4pioneer/ParametersDisplayer.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/ParametersDisplayer.java
@@ -1,8 +1,8 @@
 package com.github.jwchung.junit4pioneer;
 
 @FunctionalInterface
-public interface ParametersDisplayer<T> {
-    String display(T parameters);
+public interface ParametersDisplayer<ParametersT> {
+    String display(ParametersT parameters);
 
     /**
      * Represents the empty displayer.

--- a/src/main/java/com/github/jwchung/junit4pioneer/WithParametersDisplayerBuilder.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/WithParametersDisplayerBuilder.java
@@ -2,12 +2,13 @@ package com.github.jwchung.junit4pioneer;
 
 import java.util.stream.Stream;
 
-public class WithParametersDisplayerBuilder<T> {
-    private final Stream<? extends T> testData;
-    private final ParametersDisplayer<? super T> displayer;
+public class WithParametersDisplayerBuilder<ParametersT> {
+    private final Stream<? extends ParametersT> testData;
+    private final ParametersDisplayer<? super ParametersT> displayer;
 
     WithParametersDisplayerBuilder(
-            Stream<? extends T> testData, ParametersDisplayer<? super T> displayer) {
+            Stream<? extends ParametersT> testData,
+            ParametersDisplayer<? super ParametersT> displayer) {
         this.testData = testData;
         this.displayer = displayer;
     }
@@ -20,19 +21,19 @@ public class WithParametersDisplayerBuilder<T> {
      * @return The first-class test cases
      */
     public Stream<FirstClassTestCase> run(
-            FirstClassTestCaseWithParameters<? super T> testCase) {
+            FirstClassTestCaseWithParameters<? super ParametersT> testCase) {
         return displayer == ParametersDisplayer.getEmpty()
                 ? runWithoutPhrase(testCase)
                 : runWithPhrase(testCase);
     }
 
     private Stream<FirstClassTestCase> runWithoutPhrase(
-            FirstClassTestCaseWithParameters<? super T> testCase) {
+            FirstClassTestCaseWithParameters<? super ParametersT> testCase) {
         return testData.map(parameters -> () -> testCase.run(parameters));
     }
 
     private Stream<FirstClassTestCase> runWithPhrase(
-            FirstClassTestCaseWithParameters<? super T> testCase) {
+            FirstClassTestCaseWithParameters<? super ParametersT> testCase) {
         return testData.map(parameters -> {
             String phrase = displayer.display(parameters);
             return new ParametersDisplayableTestCase(phrase) {

--- a/src/main/java/com/github/jwchung/junit4pioneer/WithTestDataBuilder.java
+++ b/src/main/java/com/github/jwchung/junit4pioneer/WithTestDataBuilder.java
@@ -2,19 +2,20 @@ package com.github.jwchung.junit4pioneer;
 
 import java.util.stream.Stream;
 
-public class WithTestDataBuilder<T> {
-    private final Stream<? extends T> testData;
+public class WithTestDataBuilder<ParametersT> {
+    private final Stream<? extends ParametersT> testData;
 
-    WithTestDataBuilder(Stream<? extends T> testData) {
+    WithTestDataBuilder(Stream<? extends ParametersT> testData) {
         this.testData = testData;
     }
 
-    public WithParametersDisplayerBuilder<T> displayParameters(
-            ParametersDisplayer<? super T> displayer) {
+    public WithParametersDisplayerBuilder<ParametersT> displayParameters(
+            ParametersDisplayer<? super ParametersT> displayer) {
         return new WithParametersDisplayerBuilder<>(testData, displayer);
     }
 
-    public Stream<FirstClassTestCase> run(FirstClassTestCaseWithParameters<? super T> testCase) {
+    public Stream<FirstClassTestCase> run(
+            FirstClassTestCaseWithParameters<? super ParametersT> testCase) {
         return displayParameters(ParametersDisplayer.getEmpty()).run(testCase);
     }
 }


### PR DESCRIPTION
renames the generic type names to `ParametersT` to reveal its meaning.