### PR TITLE
build: configure checkstyle tasks to be run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,13 @@ if (project.hasProperty("semver")) {
     version semver
 }
 
-
 repositories {
     mavenCentral()
 }
 
 checkstyle {
     toolVersion = '8.1'
+
 }
 
 dependencies {
@@ -99,3 +99,5 @@ nexusStaging {
     stagingProfileId = "845535153553b"
 }
 
+classes.finalizedBy checkstyleMain
+testClasses.finalizedBy checkstyleTest


### PR DESCRIPTION
When IntelliJ IDE build a project, the classes and testClasses tasks of
gradle are run basically.  To forcibly include the checkstyle tasks
while IDE build builds, the finalizedBy function sets to be called.